### PR TITLE
Refactor and tweaks

### DIFF
--- a/src/clm/clm_data.py
+++ b/src/clm/clm_data.py
@@ -1,0 +1,50 @@
+from datasets import Features, Value, load_dataset
+
+
+def add_prefix(example, unk_token="unk"):
+    a = unk_token if example["angle"] is None else example["angle"]
+    d = (
+        unk_token
+        if example["display_difficulty"] is None
+        else str(round(example["display_difficulty"]))
+    )
+    example["frames"] = "a" + a + "d" + d + example["frames"]
+    return example
+
+
+def load_training_datasets():
+    dataset = load_dataset(
+        "csv",
+        data_files="climbs.csv",
+        delimiter=",",
+        features=Features(
+            {
+                "frames": Value("string"),
+                "display_difficulty": Value("float"),
+                "quality_average": Value("float"),
+                "angle": Value("string"),
+            }
+        ),
+        split="train",
+    )
+
+    datasets = dataset.map(add_prefix).train_test_split()
+    return datasets
+
+
+def tokenize_dataset(dataset, tokenizer):
+    return dataset.map(lambda example: tokenizer(example["frames"]), batched=True)
+
+
+def preprocess_datasets(datasets, tokenizer):
+    for dataset_name in ("train", "test"):
+        col_names = datasets[dataset_name].column_names
+        datasets[dataset_name] = tokenize_dataset(
+            datasets[dataset_name], tokenizer
+        ).remove_columns(col_names)
+    return datasets
+
+
+def batch_iterator(datasets, batch_size):
+    for i in range(0, len(datasets["train"]), batch_size):
+        yield datasets["train"][i : i + batch_size]["frames"]

--- a/src/clm/clm_gen.py
+++ b/src/clm/clm_gen.py
@@ -1,9 +1,9 @@
-import pprint
 import re
 
-from transformers import AutoTokenizer, GPT2LMHeadModel, GPT2Config, pipeline
+import torch
+from transformers import AutoTokenizer, GPT2Config, GPT2LMHeadModel, pipeline
 
-checkpoint = None  # "17900"
+checkpoint = "2000"  # "17900"
 
 token_dir = "clm-model"
 model_dir = token_dir if checkpoint is None else token_dir + "/checkpoint-" + checkpoint
@@ -29,8 +29,11 @@ def remove_non_pr(match):
 
 for pn, prompt in enumerate(prompts):
     for n in range(5):
-        out = generator(prompt, do_sample=True, num_beams=1)[0]
+        encoded = tokenizer(prompt, return_tensors="pt", return_attention_mask=True)
+        with torch.no_grad():
+            model_output = model(encoded["input_ids"], output_hidden_states=True)
 
+        out = generator(prompt, do_sample=True, num_beams=1)[0]
         non_pr = []
         out = re.sub(r"([^pr\d]\d+)", remove_non_pr, out["generated_text"])
 

--- a/src/clm/clm_tok.py
+++ b/src/clm/clm_tok.py
@@ -1,0 +1,98 @@
+from itertools import groupby
+
+from rich.console import Console
+from rich.pretty import pprint
+from tokenizers import Regex, Tokenizer, models, pre_tokenizers
+from tokenizers.processors import TemplateProcessing
+from tokenizers.trainers import WordLevelTrainer
+from transformers import PreTrainedTokenizerFast
+
+from clm_data import batch_iterator, load_training_datasets
+
+console = Console()
+
+OUT_DIR = "clm-model"
+
+datasets = load_training_datasets()
+
+# Train Tokenizer
+
+max_length = 48
+
+special_tokens = {
+    "bos_token": "<s>",
+    "eos_token": "</s>",
+    "unk_token": "<unk>",
+    "pad_token": "<pad>",
+    "cls_token": "<cls>",
+}
+
+tokenizer = Tokenizer(models.WordLevel(unk_token=special_tokens["unk_token"]))
+tokenizer.enable_padding(length=max_length, pad_token=special_tokens["pad_token"])
+tokenizer.enable_truncation(max_length=max_length)
+added = tokenizer.add_special_tokens(list(special_tokens.values()))
+print(f"Added {added} tokens to Tokenizer")
+
+tokenizer.pre_tokenizer = pre_tokenizers.Split(
+    Regex(r"([ad]\d+|p\d+r\d+)"), behavior="isolated"
+)
+
+bos_token_id = tokenizer.token_to_id(special_tokens["bos_token"])
+eos_token_id = tokenizer.token_to_id(special_tokens["eos_token"])
+cls_token_id = tokenizer.token_to_id(special_tokens["cls_token"])
+
+tokenizer.post_processor = TemplateProcessing(
+    single=special_tokens["bos_token"]
+    + " $A "
+    + special_tokens["cls_token"]
+    + " "
+    + special_tokens["eos_token"],
+    special_tokens=[
+        (special_tokens["eos_token"], eos_token_id),
+        (special_tokens["bos_token"], bos_token_id),
+        (special_tokens["cls_token"], cls_token_id),
+    ],
+)
+
+batch_size = 1000
+
+console.print(f"Training tokenizer")
+trainer = WordLevelTrainer(special_tokens=list(special_tokens.values()))
+tokenizer.train_from_iterator(batch_iterator(datasets, batch_size), trainer=trainer)
+
+
+def inspect_tokenizer(tokenizer):
+    vocab_list = list(tokenizer.get_vocab().items())
+
+    for i in range(0, 25, 5):
+        pprint(vocab_list[i : i + 5])
+    for i in range(len(vocab_list) - 25, len(vocab_list)):
+        pprint(vocab_list[i : i + 5])
+
+    def yield_collapse_repeats(encoded_tokens):
+        for token, group in groupby(encoded_tokens):
+            repeat_count = len(list(group)) - 1
+            if repeat_count > 0:
+                yield (token, repeat_count + 1)
+            else:
+                yield token
+
+    samples = ["p1596r15p1597r14", "p1595r15p1596r12", "a40d15p1595r15p1596r12"]
+    for sample in samples:
+        pprint(list(yield_collapse_repeats(tokenizer.encode(sample).tokens)))
+
+
+inspect_tokenizer(tokenizer)
+
+tokenizer_pretrained = PreTrainedTokenizerFast(
+    tokenizer_object=tokenizer,
+    model_max_length=max_length,
+    padding_side="right",
+    truncation_side="right",
+)
+added = tokenizer_pretrained.add_special_tokens(special_tokens)
+console.print(f"Added {added} special tokens to PreTrainedTokenizer")
+
+# https://huggingface.co/docs/transformers/en/main_classes/tokenizer#transformers.PreTrainedTokenizer.add_special_tokens.example
+console.print(f"Saving to {OUT_DIR}")
+tokenizer_pretrained.save_pretrained(OUT_DIR)


### PR DESCRIPTION
# DRAFT - do not merge

# Summary

I originally intended to simply kick the tires on this. That lead to this:

- Separate out the tokenizer training (it's fast, but might as well... makes training and generate slightly cleaner)
- Adjust some of the training parameter to match NanoGPT (not 100% sure yet if this was a good move)
- Add rich console/pprint because it looks nice
- Add a "cls" token that can be used to extract sequence embeddings (in theory... ran out of time; should be at the end but not sure if it goes after eos_token or right before it -- in BERT models I think it gets prepended)
- Upgrade the baby model to a slightly larger baby model
- Shrink vocab size to nearest multiple of 64. Oops. Alsop note, this optimization might only matter on CUDA but could help mps a little. Pretty different architectures. In any case, shouldn't expand the vocab more than we need to. Smaller vocab=faster training and inference
- Some opinionated python code golfing

Don't love the minor (but real) headache induced by splitting from a (close to) single file implementation. Python imports are a bit fussy.