### PR TITLE
Add PenaltyStatsCallback for TensorBoard logging

### DIFF
--- a/src/climb_clm/penalty_stats_callback.py
+++ b/src/climb_clm/penalty_stats_callback.py
@@ -4,15 +4,21 @@ from penalizer import Penalizer
 
 
 class PenaltyStatsCallback(TensorBoardCallback):
-    """Callback to generate routes and log penalty statistics to TensorBoard during evaluation."""
+    """Callback to generate routes and log penalty statistics to TensorBoard during evaluation.
 
-    def __init__(self, tokenizer, num_routes=100, prompts=None):
+    Args:
+        tokenizer: The tokenizer used for the model
+        num_routes: Number of routes to generate per prompt for statistics (default: 30)
+        prompts: List of (prompt_string, metric_name) tuples. If None, uses default prompts.
+                Default prompts test angle/difficulty parsing, partial climb completion, and empty input.
+    """
+
+    def __init__(self, tokenizer, num_routes=30, prompts=None):
         super().__init__()
         self.tokenizer = tokenizer
         self.num_routes = num_routes
         self.penalizer = Penalizer(tokenizer)
 
-        # Default prompts if none provided
         if prompts is None:
             self.prompts = [
                 ("a20d20", "angle_difficulty"),
@@ -24,12 +30,9 @@ class PenaltyStatsCallback(TensorBoardCallback):
 
     def on_evaluate(self, args, state, control, model, logs=None, **kwargs):
         """Generate routes and log penalty statistics during evaluation."""
-
-        # Get the current step for logging
         current_step = state.global_step
-
         print()
-        # Generate routes for each prompt and collect statistics
+
         penalty_logs = {}
         for prompt, prompt_name in self.prompts:
             print(
@@ -38,7 +41,6 @@ class PenaltyStatsCallback(TensorBoardCallback):
 
             penalty_stats = self._generate_and_analyze_routes(model, prompt)
 
-            # Collect penalty stats for logging
             penalty_logs[f"generation_{prompt_name}/penalty_free_pct"] = penalty_stats[
                 "penalty_free_pct"
             ]
@@ -49,7 +51,6 @@ class PenaltyStatsCallback(TensorBoardCallback):
                 "unique_pct"
             ]
 
-            # Print summary to console
             print(
                 f"  Penalty-free: {penalty_stats['penalty_free_count']}/{self.num_routes} ({penalty_stats['penalty_free_pct']:.1f}%)"
             )
@@ -58,7 +59,6 @@ class PenaltyStatsCallback(TensorBoardCallback):
             )
             print(f"  Avg penalty score: {penalty_stats['penalty_score']:.3f}")
 
-        # Log directly to TensorBoard using self.tb_writer
         if self.tb_writer:
             for metric_name, value in penalty_logs.items():
                 self.tb_writer.add_scalar(metric_name, value, current_step)
@@ -72,31 +72,20 @@ class PenaltyStatsCallback(TensorBoardCallback):
         unique_climbs = set()
 
         for _ in range(self.num_routes):
-            # Generate tokens for the route
             tokens = generate_tokens(self.tokenizer, model, prompt)
-
-            # Convert tokens to climb to get frames for uniqueness check
             climb = tokens_to_climb(self.tokenizer, tokens)
             unique_climbs.add(climb["frames"])
 
-            # Compute penalties and penalty score
             climb_penalties = self.penalizer.compute_penalties(tokens)
             penalty_score = self.penalizer.compute_penalty_score(climb_penalties)
 
-            # Count penalty-free routes
             if not climb_penalties:
                 penalty_free_count += 1
 
-            # Accumulate penalty scores
             total_penalty_score += penalty_score
 
-        # Calculate penalty-free percentage
         penalty_free_pct = (penalty_free_count / self.num_routes) * 100
-
-        # Calculate average penalty score
         avg_penalty_score = total_penalty_score / self.num_routes
-
-        # Calculate unique percentage
         unique_count = len(unique_climbs)
         unique_pct = (unique_count / self.num_routes) * 100
 

--- a/src/climb_clm/penalty_stats_callback.py
+++ b/src/climb_clm/penalty_stats_callback.py
@@ -1,0 +1,109 @@
+from transformers.integrations import TensorBoardCallback
+from generator import generate_tokens, tokens_to_climb
+from penalizer import Penalizer
+
+
+class PenaltyStatsCallback(TensorBoardCallback):
+    """Callback to generate routes and log penalty statistics to TensorBoard during evaluation."""
+
+    def __init__(self, tokenizer, num_routes=100, prompts=None):
+        super().__init__()
+        self.tokenizer = tokenizer
+        self.num_routes = num_routes
+        self.penalizer = Penalizer(tokenizer)
+
+        # Default prompts if none provided
+        if prompts is None:
+            self.prompts = [
+                ("a20d20", "angle_difficulty"),
+                ("a20d20p1143r12p1162r12p1394r14", "partial_climb"),
+                ("", "empty"),
+            ]
+        else:
+            self.prompts = prompts
+
+    def on_evaluate(self, args, state, control, model, logs=None, **kwargs):
+        """Generate routes and log penalty statistics during evaluation."""
+
+        # Get the current step for logging
+        current_step = state.global_step
+
+        print()
+        # Generate routes for each prompt and collect statistics
+        penalty_logs = {}
+        for prompt, prompt_name in self.prompts:
+            print(
+                f"\nCollecting penalty stats for '{prompt_name}' at step {current_step}:"
+            )
+
+            penalty_stats = self._generate_and_analyze_routes(model, prompt)
+
+            # Collect penalty stats for logging
+            penalty_logs[f"generation_{prompt_name}/penalty_free_pct"] = penalty_stats[
+                "penalty_free_pct"
+            ]
+            penalty_logs[f"generation_{prompt_name}/penalty_score"] = penalty_stats[
+                "penalty_score"
+            ]
+            penalty_logs[f"generation_{prompt_name}/unique_pct"] = penalty_stats[
+                "unique_pct"
+            ]
+
+            # Print summary to console
+            print(
+                f"  Penalty-free: {penalty_stats['penalty_free_count']}/{self.num_routes} ({penalty_stats['penalty_free_pct']:.1f}%)"
+            )
+            print(
+                f"  Unique climbs: {penalty_stats['unique_count']}/{self.num_routes} ({penalty_stats['unique_pct']:.1f}%)"
+            )
+            print(f"  Avg penalty score: {penalty_stats['penalty_score']:.3f}")
+
+        # Log directly to TensorBoard using self.tb_writer
+        if self.tb_writer:
+            for metric_name, value in penalty_logs.items():
+                self.tb_writer.add_scalar(metric_name, value, current_step)
+        else:
+            print("Warning: TensorBoard writer not available")
+
+    def _generate_and_analyze_routes(self, model, prompt):
+        """Generate routes for a given prompt and return penalty statistics."""
+        penalty_free_count = 0
+        total_penalty_score = 0
+        unique_climbs = set()
+
+        for _ in range(self.num_routes):
+            # Generate tokens for the route
+            tokens = generate_tokens(self.tokenizer, model, prompt)
+
+            # Convert tokens to climb to get frames for uniqueness check
+            climb = tokens_to_climb(self.tokenizer, tokens)
+            unique_climbs.add(climb["frames"])
+
+            # Compute penalties and penalty score
+            climb_penalties = self.penalizer.compute_penalties(tokens)
+            penalty_score = self.penalizer.compute_penalty_score(climb_penalties)
+
+            # Count penalty-free routes
+            if not climb_penalties:
+                penalty_free_count += 1
+
+            # Accumulate penalty scores
+            total_penalty_score += penalty_score
+
+        # Calculate penalty-free percentage
+        penalty_free_pct = (penalty_free_count / self.num_routes) * 100
+
+        # Calculate average penalty score
+        avg_penalty_score = total_penalty_score / self.num_routes
+
+        # Calculate unique percentage
+        unique_count = len(unique_climbs)
+        unique_pct = (unique_count / self.num_routes) * 100
+
+        return {
+            "penalty_free_count": penalty_free_count,
+            "penalty_free_pct": penalty_free_pct,
+            "penalty_score": avg_penalty_score,
+            "unique_count": unique_count,
+            "unique_pct": unique_pct,
+        }

--- a/src/climb_clm/penalty_stats_callback.py
+++ b/src/climb_clm/penalty_stats_callback.py
@@ -21,8 +21,8 @@ class PenaltyStatsCallback(TensorBoardCallback):
 
         if prompts is None:
             self.prompts = [
-                ("a20d20", "angle_difficulty"),
-                ("a20d20p1143r12p1162r12p1394r14", "partial_climb"),
+                ("a20d20", "ang_diff"),
+                ("a20d20p1143r12p1162r12p1394r14", "partial"),
                 ("", "empty"),
             ]
         else:
@@ -41,15 +41,13 @@ class PenaltyStatsCallback(TensorBoardCallback):
 
             penalty_stats = self._generate_and_analyze_routes(model, prompt)
 
-            penalty_logs[f"generation_{prompt_name}/penalty_free_pct"] = penalty_stats[
+            penalty_logs[f"gen_{prompt_name}/penalty_free_pct"] = penalty_stats[
                 "penalty_free_pct"
             ]
-            penalty_logs[f"generation_{prompt_name}/penalty_score"] = penalty_stats[
+            penalty_logs[f"gen_{prompt_name}/penalty_score"] = penalty_stats[
                 "penalty_score"
             ]
-            penalty_logs[f"generation_{prompt_name}/unique_pct"] = penalty_stats[
-                "unique_pct"
-            ]
+            penalty_logs[f"gen_{prompt_name}/unique_pct"] = penalty_stats["unique_pct"]
 
             print(
                 f"  Penalty-free: {penalty_stats['penalty_free_count']}/{self.num_routes} ({penalty_stats['penalty_free_pct']:.1f}%)"

--- a/src/climb_clm/train.py
+++ b/src/climb_clm/train.py
@@ -1,12 +1,11 @@
 import argparse
 import pprint
 from datetime import datetime
-from pathlib import Path
 
 from data import load_training_datasets, preprocess_datasets
 from train_tokenizer import train_tokenizer
+from penalty_stats_callback import PenaltyStatsCallback
 from transformers import (
-    AutoTokenizer,
     DataCollatorForLanguageModeling,
     GPT2Config,
     GPT2LMHeadModel,
@@ -14,7 +13,6 @@ from transformers import (
     TrainingArguments,
     EarlyStoppingCallback,
 )
-from transformers.trainer_utils import SchedulerType
 
 parser = argparse.ArgumentParser(description="Train CLM model")
 parser.add_argument("--run-name", type=str, help="Name for this training run")
@@ -94,6 +92,7 @@ trainer = Trainer(
         EarlyStoppingCallback(
             early_stopping_patience=5, early_stopping_threshold=0.0001
         ),
+        PenaltyStatsCallback(tokenizer, num_routes=100),
     ],
 )
 

--- a/src/climb_clm/train.py
+++ b/src/climb_clm/train.py
@@ -92,7 +92,7 @@ trainer = Trainer(
         EarlyStoppingCallback(
             early_stopping_patience=5, early_stopping_threshold=0.0001
         ),
-        PenaltyStatsCallback(tokenizer, num_routes=100),
+        PenaltyStatsCallback(tokenizer),
     ],
 )
 


### PR DESCRIPTION
Adds callback to log penalty statistics to TensorBoard during training.

Tracks penalty_free_pct, penalty_score, and unique_pct for three prompt types.

🤖 Generated with [Claude Code](https://claude.ai/code)